### PR TITLE
readd the target externaldns annotation

### DIFF
--- a/environment/values.yaml
+++ b/environment/values.yaml
@@ -5,7 +5,7 @@ ingress:
   enabled: true
   className: nginx
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: "mirko.rojandinc.se"
+    external-dns.alpha.kubernetes.io/target: tunnel.rojandinc.se
     nginx.ingress.kubernetes.io/enable-global-auth: "false"
   hosts:
     - host: mirko.rojandinc.se


### PR DESCRIPTION
External-dns is failing currently due to the change we [did](https://github.com/Mirko143-spec/MiranDinc/commit/e802e4b735a699aaf4faabc578ab495faaf7bda1).
We removed the wrong ingress annotation, in this PR I've fixed that and removed the appropriate annotation.